### PR TITLE
Formatted files using `yarn format`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,41 +2,41 @@
 
 name: Build and Deploy to Pages
 on:
-    push:
-        branches: ['main']
-    workflow_dispatch:
+  push:
+    branches: ['main']
+  workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-    contents: read
-    pages: write
-    id-token: write
+  contents: read
+  pages: write
+  id-token: write
 # Allow one concurrent deployment
 concurrency:
-    group: 'pages'
-    cancel-in-progress: true
+  group: 'pages'
+  cancel-in-progress: true
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/configure-pages@v1
-              id: pages
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 16
-                  cache: 'yarn'
-            - run: yarn install
-            - run: yarn build
-            - name: Upload artifact
-              uses: actions/upload-pages-artifact@v1
-              with:
-                  path: ./build
-    deploy:
-        runs-on: ubuntu-latest
-        needs: build
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
-        steps:
-            - uses: actions/deploy-pages@v1
-              id: deployment
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v1
+        id: pages
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./build
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v1
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ yarn storybook
 ```
 
 To run unit tests:
+
 ```bash
 yarn test:unit
 ```

--- a/src/stories/components/QuestForm.stories.ts
+++ b/src/stories/components/QuestForm.stories.ts
@@ -4,14 +4,14 @@ import { Quest } from '$lib/quest';
 
 const meta = {
 	title: 'Components/QuestForm',
-	component: QuestForm,
+	component: QuestForm
 } satisfies Meta<QuestForm>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    args: {
-        value: new Quest(),
-    }
+	args: {
+		value: new Quest()
+	}
 };

--- a/src/stories/components/QuestSummary.stories.ts
+++ b/src/stories/components/QuestSummary.stories.ts
@@ -4,19 +4,19 @@ import { Quest } from '$lib/quest';
 
 const meta = {
 	title: 'Components/QuestSummary',
-	component: QuestSummary,
+	component: QuestSummary
 } satisfies Meta<QuestSummary>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-    args: {
-        value: new Quest({
-            id: 1,
-            title: "Do some cardio",
-            description: "Run on the treadmill for at least 30 minutes",
-            is_completed: false,
-        }),
-    }
+	args: {
+		value: new Quest({
+			id: 1,
+			title: 'Do some cardio',
+			description: 'Run on the treadmill for at least 30 minutes',
+			is_completed: false
+		})
+	}
 };

--- a/src/stories/pages/Dashboard.stories.ts
+++ b/src/stories/pages/Dashboard.stories.ts
@@ -7,8 +7,7 @@ const meta = {
 	title: 'Pages/Dashboard',
 	component: Dashboard,
 	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
-	parameters: {
-	},
+	parameters: {}
 } satisfies Meta<Dashboard>;
 
 export default meta;

--- a/src/stories/pages/Landing.stories.ts
+++ b/src/stories/pages/Landing.stories.ts
@@ -7,8 +7,7 @@ const meta = {
 	title: 'Pages/Home',
 	component: Landing,
 	// This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/7.0/react/writing-docs/docs-page
-	parameters: {
-	},
+	parameters: {}
 } satisfies Meta<Landing>;
 
 export default meta;


### PR DESCRIPTION
Clean-up PR.

Due to prettier not being properly configured on my machine, I have repeatedly merged code that does not adhere to the formatting standards of `yarn format`.  This is my fix-it PR to address that mistake.

Note formatting changes to `.storybook/preview.js` have been explicitly ignored in this commit to avoid merge conflicts with PR #6, which also modifies that file.