### PR TITLE
Nicholas guyett/quest deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can preview the production build with `yarn preview`.
   - Prevent parent quest from completing if required subquests are in-complete
   - Allow parent quests to auto-complete when sub-quests complete
 - "Persistent Notifications"
-  - [ ] Add deadlines
+  - [x] Add deadlines
   - [ ] Add notification support
   - [ ] Configurable reminder times
   - [ ] Repeatable reminders

--- a/src/lib/QuestForm.svelte
+++ b/src/lib/QuestForm.svelte
@@ -54,6 +54,18 @@
 		/>
 	</div>
 	<div class="mb-3">
+		<label class="form-label" for="quest-form-target-completion-datetime">
+			{$i18n.t('quests.fields.target_completion_datetime')}
+		</label>
+		<input
+			type="datetime-local"
+			name="target-completion-datetime"
+			id="quest-form-target-completion-datetime"
+			class="form-control"
+			bind:value={updatedValue.target_completion_datetime}
+		/>
+	</div>
+	<div class="mb-3">
 		<button class="btn btn-primary" type="submit">{$i18n.t('quests.cta.save')}</button>
 		<button class="btn btn-danger" type="button" on:click={close}>
 			{$i18n.t('quests.cta.close')}

--- a/src/lib/QuestForm.svelte
+++ b/src/lib/QuestForm.svelte
@@ -23,7 +23,12 @@
 
 <form on:submit|preventDefault={save}>
 	<div class="mb-3">
-		<label class="form-label" for="quest-form-title">{$i18n.t('quests.fields.title')}</label>
+		<label class="form-label" for="quest-form-title">
+			{$i18n.t('quests.fields.title')}
+			<abbr title={$i18n.t('quests.field-is-required.expanded')}>
+				{$i18n.t('quests.field-is-required.abbreviation')}
+			</abbr>
+		</label>
 		<input
 			name="title"
 			id="quest-form-title"
@@ -36,6 +41,9 @@
 	<div class="mb-3">
 		<label class="form-row" for="quest-form-description">
 			{$i18n.t('quests.fields.description')}
+			<abbr title={$i18n.t('quests.field-is-required.expanded')}>
+				{$i18n.t('quests.field-is-required.abbreviation')}
+			</abbr>
 		</label>
 		<textarea
 			name="description"

--- a/src/lib/QuestSummary.svelte
+++ b/src/lib/QuestSummary.svelte
@@ -39,7 +39,20 @@
 </script>
 
 <article class="card quest-summary">
-	<header class="card-header">{value.title}</header>
+	<header class="card-header">
+		{value.title}
+		{#if value.target_completion_datetime}
+			&mdash;
+			<small>
+				{$i18n.t('quests.complete-by', {
+					val: value.target_completion_datetime,
+					formatParams: {
+						val: { dateStyle: 'short', timeStyle: 'short' }
+					}
+				})}
+			</small>
+		{/if}
+	</header>
 	<div class="card-body">
 		<p class="card-text">{value.description}</p>
 	</div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -10,7 +10,7 @@ class QuestDb extends Dexie {
 		this.version(1).stores({
 			quests: '++id, is_completed'
 		});
-		this.quests.mapToClass(Quest);
+		this.quests.hook('reading', quest => new Quest(quest));
 	}
 }
 

--- a/src/lib/quest.ts
+++ b/src/lib/quest.ts
@@ -3,23 +3,35 @@ export class Quest {
 	public title: string;
 	public description: string;
 	public is_completed: boolean;
+	public target_completion_datetime?: Date;
 
 	public constructor(
 		{
 			id,
 			title,
 			description,
-			is_completed
+			is_completed,
+			target_completion_datetime
 		}: {
 			id: any;
 			title: string;
 			description: string;
 			is_completed: boolean;
-		} = { id: undefined, title: '', description: '', is_completed: false }
+			target_completion_datetime?: Date;
+		} = {
+			id: undefined,
+			title: '',
+			description: '',
+			is_completed: false,
+			target_completion_datetime: undefined
+		}
 	) {
 		this.id = id || undefined;
 		this.title = title || '';
 		this.description = description || '';
 		this.is_completed = is_completed || false;
+		if (target_completion_datetime) {
+			this.target_completion_datetime = new Date(target_completion_datetime);
+		}
 	}
 }

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -14,11 +14,14 @@ export const DEFAULT_LOCALE = Locale.en;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 export type Namespace = (typeof NAMESPACES)[number];
 
-export const GLOBAL_OPTIONS = {
+export const GLOBAL_OPTIONS: InitOptions = {
 	fallbackLng: [DEFAULT_LOCALE],
 	ns: NAMESPACES,
 	keySeparator: '.',
 	nsSeparator: '.',
+	interpolation: {
+		escapeValue: false // Escaping is already handled by svelte
+	}
 };
 let environmentSpecificOptions: Partial<InitOptions> = {};
 if (browser) {

--- a/src/stories/components/QuestSummary.stories.ts
+++ b/src/stories/components/QuestSummary.stories.ts
@@ -10,13 +10,27 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const baseQuest = new Quest({
+	id: 1,
+	title: 'Do some cardio',
+	description: 'Run on the treadmill for at least 30 minutes',
+	is_completed: false
+});
+
+const now = new Date();
+const tomorrow = new Date(now.getTime() + 1000 * 60 * 60 * 24);
+
 export const Default: Story = {
 	args: {
+		value: baseQuest
+	}
+};
+
+export const WithDeadline: Story = {
+	args: {
 		value: new Quest({
-			id: 1,
-			title: 'Do some cardio',
-			description: 'Run on the treadmill for at least 30 minutes',
-			is_completed: false
+			...baseQuest,
+			target_completion_datetime: tomorrow
 		})
 	}
 };

--- a/static/locales/en/quests.json
+++ b/static/locales/en/quests.json
@@ -13,10 +13,12 @@
 	"fields": {
 		"title": "Title",
 		"description": "Description",
+		"target_completion_datetime": "Target Completion Date & Time"
 	},
 	"field-is-required": {
 		"expanded": "This field is required",
 		"abbreviation": "*"
 	},
+	"complete-by": "Should be completed by: {{val, datetime}}",
 	"no-pending-quests": "No pending quests"
 }

--- a/static/locales/en/quests.json
+++ b/static/locales/en/quests.json
@@ -12,7 +12,11 @@
 	},
 	"fields": {
 		"title": "Title",
-		"description": "Description"
+		"description": "Description",
+	},
+	"field-is-required": {
+		"expanded": "This field is required",
+		"abbreviation": "*"
 	},
 	"no-pending-quests": "No pending quests"
 }


### PR DESCRIPTION
Allows deadlines or "target completion dates" to be set when creating a quest.

When a deadline is set on a quest, `QuestSummary` includes that information in the card title.

Avoiding the use of "deadline" in the actual UI to avoid causing deadline anxiety.  May make a setting to change this wording in the future.

Since the deadlines are optional, I've also updated the quest form to make it clear which fields are required and which are optional.

Added a new storybook story which uses a quest with a deadline set.